### PR TITLE
current-color

### DIFF
--- a/blink1.el
+++ b/blink1.el
@@ -167,7 +167,7 @@ displayed."
           (rgbvals (s-split "," rgbvals)))
     (--map (string-to-number it 16) rgbvals)))
 
-(defmacro blink1-with-current-color (&rest body)
+(defmacro blink1-save-current-color (&rest body)
   "Read the current color, execute BODY, then switch back to that color."
   (let ((sym (gensym)))
     `(let ((,sym (blink1--current-color)))

--- a/blink1.el
+++ b/blink1.el
@@ -167,6 +167,13 @@ displayed."
           (rgbvals (s-split "," rgbvals)))
     (--map (string-to-number it 16) rgbvals)))
 
+(defmacro blink1-with-current-color (&rest body)
+  "Read the current color, execute BODY, then switch back to that color."
+  (let ((sym (gensym)))
+    `(let ((,sym (blink1--current-color)))
+       ,@body
+       (blink1-set-color ,sym))))
+
 (provide 'blink1)
 
 ;;; blink1.el ends here

--- a/blink1.el
+++ b/blink1.el
@@ -155,6 +155,18 @@ Optionally specify DEVICE-ID to control.  Controls all devices by default."
   (interactive (list (blink1-read-rgb-color)))
   (blink1-play-pattern (list color-a color-b)))
 
+(defun blink1--current-color ()
+  "Return the current color of the blinky.
+
+Actually, this returns the last input color of the
+blinky, which might not be what is currently
+displayed."
+  (-let* ((output (s-chomp (blink1-command "--rgbread")))
+          ((_ rgbvals) (s-split ": " output))
+          (rgbvals  (s-replace "0x" "" rgbvals))
+          (rgbvals (s-split "," rgbvals)))
+    (--map (string-to-number it 16) rgbvals)))
+
 (provide 'blink1)
 
 ;;; blink1.el ends here


### PR DESCRIPTION
First add `blink1--current-color`. This attempts to read the current color of the blinky. It is certainly not perfect, but it seems to work okay in the simplest case at least.

Next add `blink1-with-current-color`. This is a macro that makes it easier to write functions of the form "do something, then switch back to what it was before". It won't switch back to a pattern though. That will take more work.

Example:

```emacs-lisp
(defun example/flash-red ()
  (interactive)
  (blink1-with-current-color
   (blink1-set-color "red")
   (sleep-for .5)))
```